### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "jshint": "^2.5.6",
         "mocha": "^1.21.4"
     },
-    "license": "Apache License v2.0",
+    "license": "Apache-2.0",
     "bin": {},
     "main": "./raptor-util.js",
     "publishConfig": {


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/

Updating to "Apache-2.0" per https://spdx.org/licenses/ page.
