### PR TITLE
An empty string attribute should be preserved

### DIFF
--- a/attr.js
+++ b/attr.js
@@ -3,7 +3,7 @@ var escapeXmlAttr = require('./escapeXml').attr;
 module.exports = function(name, value, escapeXml) {
     if (value === true) {
         value = '';
-    } else if (value == null || value === '' || value === false) {
+    } else if (value == null || value === false) {
         return '';
     } else {
         value = '="' + (escapeXml === false ? value : escapeXmlAttr(value)) + '"';


### PR DESCRIPTION
allows the following to work as expected: `attr('alt, '') === ' alt=""'`

see also: https://github.com/marko-js/marko/issues/327
