### PR TITLE
Fix for escapeXml

### DIFF
--- a/escapeXml.js
+++ b/escapeXml.js
@@ -21,7 +21,7 @@ function escapeXml(str) {
         return elTest.test(str) ? str.replace(elTestReplace, replaceChar) : str;
     }
 
-    return (str == null) ? '' : str.toString();
+    return (str == null) ? '' : escapeXml(str.toString());
 }
 
 function escapeXmlAttr(str) {
@@ -29,7 +29,7 @@ function escapeXmlAttr(str) {
         return attrTest.test(str) ? str.replace(attrReplace, replaceChar) : str;
     }
 
-    return (str == null) ? '' : str.toString();
+    return (str == null) ? '' : escapeXmlAttr(str.toString());
 }
 
 

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "1.1.1"
+  "version": "1.2.1"
 }

--- a/test/escapeXml-test.js
+++ b/test/escapeXml-test.js
@@ -1,0 +1,38 @@
+var chai = require('chai');
+chai.Assertion.includeStack = true;
+require('chai').should();
+var expect = require('chai').expect;
+
+var raptorUtil = require('../'); // Load this module just to make sure it works
+
+describe('raptor-util/escapeXml', function() {
+
+    beforeEach(function(done) {
+        done();
+    });
+
+    it ('should escape input string to HTML special chars', function () {
+        var input = '<>&"\'\n';
+        var output = raptorUtil.escapeXml(input);
+        expect(output).to.equal('&lt;>&amp;"\'\n');
+    });
+
+    it ('should escape input array of string to HTML special chars', function () {
+        var input = '<>&"\'\n';
+        var output = raptorUtil.escapeXml([input]);
+        expect(output).to.equal('&lt;>&amp;"\'\n');
+    });
+
+    it ('should escape input string to HTML special chars for attr', function () {
+        var input = '<>&"\'\n';
+        var output = raptorUtil.escapeXmlAttr(input);
+        expect(output).to.equal('&lt;&gt;&amp;&quot;&#39;&#10;');
+    });
+
+    it ('should escape input array of string to HTML special chars for attr', function () {
+        var input = '<>&"\'\n';
+        var output = raptorUtil.escapeXmlAttr([input]);
+        expect(output).to.equal('&lt;&gt;&amp;&quot;&#39;&#10;');
+    });
+
+});


### PR DESCRIPTION
Please verify if this fix is correct.  Passing an object into escapeXML by-passes the XSS code.

https://github.com/raptorjs/raptor-util/issues/5